### PR TITLE
Seasonal split of EECA data

### DIFF
--- a/etl/_13_P1_ElecCons.py
+++ b/etl/_13_P1_ElecCons.py
@@ -37,29 +37,31 @@ class EECAElectricityPercentageAnalytics(MetricsLayer):
 
         # Total energy by year
         total_energy = (
-            df.groupby("Year", as_index=False)["energyValue"]
+            df.groupby(["Year", "Month"], as_index=False)["energyValue"]
             .sum()
             .rename(columns={"energyValue": "Total_Energy"})
         )
-        print(f"      - Calculated total energy for {len(total_energy)} years")
+        print(
+            f"      - Calculated total energy for {total_energy['Year'].nunique()} years"
+        )
 
         # Electricity energy by year
         electricity_energy = (
             df.query("Category == 'Electricity'")
-            .groupby("Year", as_index=False)["energyValue"]
+            .groupby(["Year", "Month"], as_index=False)["energyValue"]
             .sum()
             .rename(columns={"energyValue": "Electricity_Energy"})
         )
         print(
-            f"      - Calculated electricity energy for {len(electricity_energy)} years"
+            f"      - Calculated electricity energy for {total_energy['Year'].nunique()} years"
         )
 
         # Merge and calculate the share
         analytics_df = total_energy.merge(
-            electricity_energy, on="Year", how="left"
+            electricity_energy, on=["Year", "Month"], how="left"
         ).assign(
             _13_P1_ElecCons=lambda x: 100 * x["Electricity_Energy"] / x["Total_Energy"]
-        )[["Year", "_13_P1_ElecCons"]]
+        )[["Year", "Month", "_13_P1_ElecCons"]]
 
         # Add metadata
         analytics_df["Metric Group"] = "Energy"

--- a/etl/_14_P1_EnergyxFuel.py
+++ b/etl/_14_P1_EnergyxFuel.py
@@ -37,12 +37,12 @@ class EECAEnergyByFuelAnalytics(MetricsLayer):
         print("\n[2/3] Aggregating energy consumption by fuel type and sector...")
 
         # Group and summarise
-        grouped = df.groupby(["Year", "Category", "Sub-Category"], as_index=False)[
-            "energyValue"
-        ].sum()
+        grouped = df.groupby(
+            ["Year", "Month", "Category", "Sub-Category"], as_index=False
+        )["energyValue"].sum()
         print(
             f"      - Aggregated to {len(grouped)} rows "
-            f"({df['Year'].nunique()} years × {df['Category'].nunique()} fuel types × {df['Sub-Category'].nunique()} sectors)"
+            f"({df['Year'].nunique()} years × {df['Month'].nunique()} months × {df['Category'].nunique()} fuel types × {df['Sub-Category'].nunique()} sectors)"
         )
 
         # Convert to MWh instead of Terajoules
@@ -57,6 +57,7 @@ class EECAEnergyByFuelAnalytics(MetricsLayer):
         grouped = grouped[
             [
                 "Year",
+                "Month",
                 "Category",
                 "Sub-Category",
                 "Metric Group",

--- a/etl/pipelines/eeca/transform.py
+++ b/etl/pipelines/eeca/transform.py
@@ -107,6 +107,51 @@ class EECAEnergyConsumptionTransformer(ProcessedLayer):
         else:
             print("      - No missing energyValue values found")
 
+        # Split the Yearly numbers by month - using an approximate season split
+        # Define months and seasonal weights (example: more energy in winter)
+        df_months = pd.DataFrame(
+            {
+                "Month": range(1, 13),
+                # Rough pattern for NZ: winter (Jun–Aug) highest, summer (Dec–Feb) lowest
+                "season_weight": [
+                    0.7,
+                    0.8,
+                    0.9,
+                    1.0,
+                    1.1,
+                    1.2,
+                    1.3,
+                    1.2,
+                    1.1,
+                    1.0,
+                    0.9,
+                    0.8,
+                ],
+            }
+        )
+        # Normalise weights so they sum to 12 (so totals are preserved)
+        df_months["season_weight"] = df_months["season_weight"] * (
+            1 / df_months["season_weight"].sum()
+        )
+
+        # Cross join years × months
+        energy_count_before = df.energyValue.sum()
+        df = (
+            df.assign(key=1)
+            .merge(df_months.assign(key=1), on="key")
+            .drop("key", axis=1)
+        )
+
+        # Apply seasonal weights
+        df["energyValue"] = df["energyValue"] * df["season_weight"]
+        df.drop(columns=["season_weight"], inplace=True)
+        print(
+            "      - Added Month column by spitting yearly data using seasonal approximation"
+        )
+        print(
+            f"      - Total Energy values match: {df.energyValue.sum() == energy_count_before}"
+        )
+
         # Step 3: Save processed data
         print("\n[3/3] Saving processed data...")
         print(f"      Output: {output_path}")


### PR DESCRIPTION
Included a crude seasonal monthly split of the yearly EECA data. Most of the changes are in the transform component of the ETL pipeline, with some small aggregation updates in the metrics component. 

There was also an issue where duplicated rows were being dropped in the EECA data, which was undercounting the energy consumption outputs. This has been resolved in this PR. 